### PR TITLE
Python 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Python
+.DS_Store
+__pycache__/
+*.py[cod]

--- a/datapackage/__init__.py
+++ b/datapackage/__init__.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from .datapackage import DataPackage  # flake8: noqa
 from .resource import Resource  # flake8: noqa
-
+from . import compat

--- a/datapackage/compat.py
+++ b/datapackage/compat.py
@@ -19,6 +19,7 @@ is_py27 = (is_py2 and _ver[1] == 7)
 if is_py2:
     import urlparse as parse
     from urllib2 import urlopen, HTTPError
+    import mock
     builtin_str = str
     bytes = str
     str = unicode
@@ -40,6 +41,7 @@ elif is_py3:
     from urllib import parse
     from urllib.request import urlopen
     from urllib.error import HTTPError
+    from unittest import mock
     csv_reader = csv.reader
     builtin_str = str
     str = str

--- a/datapackage/compat.py
+++ b/datapackage/compat.py
@@ -11,6 +11,7 @@ import csv
 _ver = sys.version_info
 is_py2 = (_ver[0] == 2)
 is_py3 = (_ver[0] == 3)
+is_py32 = (is_py3 and _ver[1] == 2)
 is_py33 = (is_py3 and _ver[1] == 3)
 is_py34 = (is_py3 and _ver[1] == 4)
 is_py27 = (is_py2 and _ver[1] == 7)
@@ -38,10 +39,13 @@ if is_py2:
             yield [str(cell, 'utf-8') for cell in row]
 
 elif is_py3:
+    if is_py32:
+        import mock
+    else:
+        from unittest import mock
     from urllib import parse
     from urllib.request import urlopen
     from urllib.error import HTTPError
-    from unittest import mock
     csv_reader = csv.reader
     builtin_str = str
     str = str
@@ -54,4 +58,3 @@ elif is_py3:
 def to_bytes(textstring, encoding='utf-8'):
     """Convert a text string to a byte string"""
     return textstring.encode(encoding)
-

--- a/datapackage/compat.py
+++ b/datapackage/compat.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import sys
+import io
+
+_ver = sys.version_info
+is_py2 = (_ver[0] == 2)
+is_py3 = (_ver[0] == 3)
+is_py33 = (is_py3 and _ver[1] == 3)
+is_py34 = (is_py3 and _ver[1] == 4)
+is_py27 = (is_py2 and _ver[1] == 7)
+
+
+if is_py2:
+    import urlparse as parse
+    from urllib2 import urlopen, HTTPError
+    builtin_str = str
+    bytes = str
+    str = unicode
+    basestring = basestring
+    numeric_types = (int, long, float)
+
+
+elif is_py3:
+    from urllib import parse
+    from urllib.request import urlopen
+    from urllib.error import HTTPError
+    builtin_str = str
+    str = str
+    bytes = bytes
+    basestring = (str, bytes)
+    numeric_types = (int, float)
+

--- a/datapackage/compat.py
+++ b/datapackage/compat.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 
 import sys
 import io
+import csv
 
 _ver = sys.version_info
 is_py2 = (_ver[0] == 2)
@@ -24,14 +25,31 @@ if is_py2:
     basestring = basestring
     numeric_types = (int, long, float)
 
+    def csv_reader(data, dialect=csv.excel, **kwargs):
+        """Read text stream (unicode on Py2.7) as CSV."""
+
+        def iterenc_utf8(data):
+            for line in data:
+                yield line.encode('utf-8')
+
+        reader = csv.reader(iterenc_utf8(data), dialect=dialect, **kwargs)
+        for row in reader:
+            yield [str(cell, 'utf-8') for cell in row]
 
 elif is_py3:
     from urllib import parse
     from urllib.request import urlopen
     from urllib.error import HTTPError
+    csv_reader = csv.reader
     builtin_str = str
     str = str
     bytes = bytes
     basestring = (str, bytes)
     numeric_types = (int, float)
+    next = lambda x: x.next()
+
+
+def to_bytes(textstring, encoding='utf-8'):
+    """Convert a text string to a byte string"""
+    return textstring.encode(encoding)
 

--- a/datapackage/datapackage.py
+++ b/datapackage/datapackage.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 # datapackage.py - Load and manage data packages defined by dataprotocols.org
 # Copyright (C) 2013 Tryggvi Björgvinsson
@@ -16,8 +20,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import urllib
-import csv
 import json
 import itertools
 import os
@@ -26,17 +28,6 @@ import time
 import base64
 import re
 import warnings
-import sys
-if sys.version_info[0] < 3:
-    import urlparse
-    urllib.parse = urlparse
-    urllib.request = urllib
-    next = lambda x: x.next()
-    bytes = str
-    str = unicode
-else:
-    import urllib.request
-
 from .resource import Resource
 from .schema import Schema
 from .sources import Source
@@ -44,6 +35,7 @@ from .licenses import License, LICENSES
 from .persons import Person
 from .util import (Specification, verify_version, parse_version,
                    format_version, is_local, is_url)
+from . import compat
 
 
 class DataPackage(Specification):
@@ -54,22 +46,22 @@ class DataPackage(Specification):
 
     DATAPACKAGE_VERSION = "1.0-beta.10"
     EXTENDABLE = True
-    SPECIFICATION = {'name': str,
+    SPECIFICATION = {'name': compat.str,
                      'resources': list,
-                     'license': str,
+                     'license': compat.str,
                      'licenses': list,
-                     'datapackage_version': str,
-                     'title': str,
-                     'description': str,
-                     'homepage': str,
-                     'version': str,
+                     'datapackage_version': compat.str,
+                     'title': compat.str,
+                     'description': compat.str,
+                     'homepage': compat.str,
+                     'version': compat.str,
                      'sources': list,
                      'keywords': list,
-                     'image': str,
+                     'image': compat.str,
                      'maintainers': list,
                      'contributors': list,
                      'publishers': list,
-                     'base': str,
+                     'base': compat.str,
                      'dataDependencies': dict}
     REQUIRED = ('name',)
     RESOURCE_CLASS = Resource
@@ -105,7 +97,7 @@ class DataPackage(Specification):
         if not args:
             super(DataPackage, self).__init__(*args, **kwargs)
         elif len(args) == 1:
-            self.base = str(args[0])
+            self.base = args[0]
             descriptor = self.get_descriptor()
             super(DataPackage, self).__init__(**descriptor)
         else:
@@ -173,7 +165,7 @@ class DataPackage(Specification):
 
         # If none of the edge cases we use the default field parsers and fall
         # back on unicode type if no parser is found
-        return self.FIELD_PARSERS.get(field['type'], str)
+        return self.FIELD_PARSERS.get(field['type'], compat.str)
 
     def open_resource(self, path):
         # If base hasn't been set we use the current directory as the base
@@ -187,8 +179,8 @@ class DataPackage(Specification):
         if is_local(base):
             resource_path = os.path.join(base, path)
         else:
-            resource_path = urllib.parse.urljoin(base, path)
-        return urllib.request.urlopen(resource_path)
+            resource_path = compat.parse.urljoin(base, path)
+        return compat.urlopen(resource_path)
 
     @property
     def name(self):
@@ -337,7 +329,7 @@ class DataPackage(Specification):
                 del self['title']
             return
 
-        self['title'] = str(value)
+        self['title'] = compat.str(value)
 
     @property
     def description(self):
@@ -354,7 +346,7 @@ class DataPackage(Specification):
                 del self['description']
             return
 
-        self['description'] = str(value)
+        self['description'] = compat.str(value)
 
     @property
     def homepage(self):
@@ -373,7 +365,7 @@ class DataPackage(Specification):
         if not is_url(value):
             raise ValueError("not a URL: {0}".format(value))
 
-        self['homepage'] = str(value)
+        self['homepage'] = compat.str(value)
 
     @property
     def version(self):
@@ -384,7 +376,7 @@ class DataPackage(Specification):
         Defaults to 0.0.1 if not specified.
 
         """
-        return self.get('version', u'0.0.1')
+        return self.get('version', '0.0.1')
 
     @version.setter
     def version(self, val):
@@ -492,7 +484,7 @@ class DataPackage(Specification):
                 del self['keywords']
             return
 
-        self['keywords'] = [str(x) for x in value]
+        self['keywords'] = [compat.str(x) for x in value]
 
     @property
     def image(self):
@@ -507,7 +499,7 @@ class DataPackage(Specification):
                 del self['image']
             return
 
-        self['image'] = str(value)
+        self['image'] = compat.str(value)
 
     @property
     def maintainers(self):
@@ -662,7 +654,7 @@ class DataPackage(Specification):
                 'fields': resource.get('schema', Schema()).get('fields', [])
             }
             # Add the resource to the resource dictionary collection
-            resources[resource.get('name', resource.get('id', u''))] = rsource
+            resources[resource.get('name', resource.get('id', ''))] = rsource
 
         # Return the resource collection
         return resources
@@ -685,7 +677,7 @@ class DataPackage(Specification):
         resource_file = (line.decode(resource.get('encoding', 'utf-8'))
                          for line in resource_file)
         # We assume CSV so we create the csv file
-        reader = csv.reader(resource_file)
+        reader = compat.csv_reader(resource_file)
         # Throw away the first line (headers)
         next(reader)
         # For each row we yield it as a dictionary where keys are the field

--- a/datapackage/datapackage.py
+++ b/datapackage/datapackage.py
@@ -27,6 +27,7 @@ import datetime
 import time
 import base64
 import re
+import io
 import warnings
 from .resource import Resource
 from .schema import Schema
@@ -178,9 +179,10 @@ class DataPackage(Specification):
         # on Windows it will try to create URLs with backslashes
         if is_local(base):
             resource_path = os.path.join(base, path)
+            return io.open(resource_path)
         else:
             resource_path = compat.parse.urljoin(base, path)
-        return compat.urlopen(resource_path)
+            return compat.urlopen(resource_path)
 
     @property
     def name(self):
@@ -700,7 +702,7 @@ class DataPackage(Specification):
                 try:
                     row_dict[field_name] = self._field_parser(field)(value)
                 except:
-                    msg = u'Field "{field}" in row {row} could not be parsed.'
+                    msg = 'Field "{field}" in row {row} could not be parsed.'
                     raise ValueError(msg.format(field=field_name, row=row_idx))
 
             yield row_dict

--- a/datapackage/licenses.py
+++ b/datapackage/licenses.py
@@ -1,10 +1,13 @@
-import sys
-if sys.version_info[0] < 3:
-    next = lambda x: x.next()
-    bytes = str
-    str = unicode
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from .util import Specification, is_url, load_licenses
+from . import compat
+
+
 LICENSES = load_licenses()
 
 
@@ -22,8 +25,8 @@ class License(Specification):
     **Open Definition license ID**.
     """
 
-    SPECIFICATION = {'type': str,
-                     'url': str}
+    SPECIFICATION = {'type': compat.str,
+                     'url': compat.str}
 
     def __init__(self, *args, **kwargs):
         # We need to pick them out in a specific order to make sure that

--- a/datapackage/persons.py
+++ b/datapackage/persons.py
@@ -1,10 +1,11 @@
-import sys
-if sys.version_info[0] < 3:
-    next = lambda x: x.next()
-    bytes = str
-    str = unicode
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from .util import Specification, is_url, is_email
+from . import compat
 
 
 class Person(Specification):
@@ -18,9 +19,9 @@ class Person(Specification):
     "email" and "web" properties.
     """
 
-    SPECIFICATION = {'name': str,
-                     'web': str,
-                     'email': str}
+    SPECIFICATION = {'name': compat.str,
+                     'web': compat.str,
+                     'email': compat.str}
     REQUIRED = ('name',)
 
     @property
@@ -34,7 +35,7 @@ class Person(Specification):
     def name(self, value):
         if not value:
             raise ValueError('A person must have a name')
-        self['name'] = str(value)
+        self['name'] = compat.str(value)
 
     @property
     def web(self):
@@ -53,7 +54,7 @@ class Person(Specification):
         if not is_url(value):
             raise ValueError("not a url: {0}".format(value))
 
-        self['web'] = str(value)
+        self['web'] = compat.str(value)
 
     @property
     def email(self):
@@ -72,4 +73,4 @@ class Person(Specification):
         if not is_email(value):
             raise ValueError("not an email address: {0}".format(value))
 
-        self['email'] = str(value)
+        self['email'] = compat.str(value)

--- a/datapackage/resource.py
+++ b/datapackage/resource.py
@@ -184,6 +184,9 @@ class Resource(Specification):
             format = mimetypes.guess_extension(self.mediatype)
             if format:
                 format = format[1:]
+                # Bug in Python: http://bugs.python.org/issue4963
+                if format in ('jpe', 'jpeg'):
+                    format = 'jpg'
             else:
                 format = ''
 

--- a/datapackage/resource.py
+++ b/datapackage/resource.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 
 import os
 import sys
+import io
 import hashlib
 import json
 import posixpath
@@ -45,7 +46,7 @@ class Resource(Specification):
 
     def _open(self, mode):
         if self.is_local:
-            return open(self.fullpath, mode)
+            return io.open(self.fullpath, mode)
         else:
             if mode not in ('r', 'rb'):
                 raise ValueError('urls can only be opened read-only')
@@ -262,7 +263,7 @@ class Resource(Specification):
         """Compute the size of the inline data"""
         if not self.data:
             raise ValueError("data is not specified")
-        bytestr = compat.bytes(json.dumps(self.data), encoding=self.encoding)
+        bytestr = compat.to_bytes(json.dumps(self.data), encoding=self.encoding)
         return len(bytestr)
 
     def _path_bytes(self):

--- a/datapackage/schema.py
+++ b/datapackage/schema.py
@@ -1,10 +1,11 @@
-from .util import Specification
-import sys
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
-if sys.version_info[0] < 3:
-    next = lambda x: x.next()
-    bytes = str
-    str = unicode
+from .util import Specification
+from . import compat
 
 
 class Field(Specification):
@@ -14,10 +15,10 @@ class Field(Specification):
     Currently this is built around the Tabular Data Package.
     """
 
-    SPECIFICATION = {'name': str,
-                     'title': str,
-                     'type': str,
-                     'format': str,
+    SPECIFICATION = {'name': compat.str,
+                     'title': compat.str,
+                     'type': compat.str,
+                     'format': compat.str,
                      'constraints': dict}
     REQUIRED = ('name',)
 
@@ -32,7 +33,7 @@ class Constraints(Specification):
                      'minLength': int,
                      'maxLength': int,
                      'unique': bool,
-                     'pattern': str,
+                     'pattern': compat.str,
                      'minimum': None,
                      'maximum': None}
 
@@ -43,9 +44,9 @@ class Reference(Specification):
     the reference to the other datapackage.
     """
 
-    SPECIFICATION = {'datapackage': str,
-                     'resource': str,
-                     'fields': (str, list)}
+    SPECIFICATION = {'datapackage': compat.str,
+                     'resource': compat.str,
+                     'fields': (compat.str, list)}
     REQUIRED = ('fields',)
 
     def __setattr__(self, attribute, value):
@@ -55,7 +56,7 @@ class Reference(Specification):
             if type(value) == list:
                 modified_value = []
                 for single_value in value:
-                    if type(single_value) == str:
+                    if type(single_value) == compat.str:
                         modified_value.append(single_value)
                     elif isinstance(single_value, Field):
                         modified_value.append(single_value.name)
@@ -64,7 +65,7 @@ class Reference(Specification):
                             'Field type ({0}) is not supported'.format(
                                 type(single_value)))
                 value = modified_value
-            elif type(value) == str:
+            elif type(value) == compat.str:
                 # We don't need to do anything with a str
                 pass
             elif isinstance(value, Field):
@@ -83,7 +84,7 @@ class ForeignKey(Specification):
     represent a foreign key in another data package.
     """
 
-    SPECIFICATION = {'fields': (str, list),
+    SPECIFICATION = {'fields': (compat.str, list),
                      'reference': Reference}
     REQUIRED = ('fields', 'reference')
 
@@ -109,7 +110,7 @@ class ForeignKey(Specification):
             if value_type == list:
                 modified_value = []
                 for single_value in value:
-                    if type(single_value) == str:
+                    if type(single_value) == compat.str:
                         modified_value.append(single_value)
                     elif isinstance(single_value, Field):
                         modified_value.append(single_value.name)
@@ -118,7 +119,7 @@ class ForeignKey(Specification):
                             'Foreign key type ({0}) is not supported'.format(
                                 type(single_value)))
                 value = modified_value
-            elif value_type == str:
+            elif value_type == compat.str:
                 # We don't need to do anything if the value is a str
                 pass
             elif isinstance(value, Field):
@@ -152,7 +153,7 @@ class Schema(Specification):
     """
 
     SPECIFICATION = {'fields': list,
-                     'primaryKey': (str, list),
+                     'primaryKey': (compat.str, list),
                      'foreignKeys': list}
 
     def __init__(self, *args, **kwargs):
@@ -174,7 +175,7 @@ class Schema(Specification):
             if type(value) == list:
                 modified_value = []
                 for single_value in value:
-                    if type(single_value) == str:
+                    if type(single_value) == compat.str:
                         if single_value in field_names:
                             modified_value.append(single_value)
                         else:
@@ -193,7 +194,7 @@ class Schema(Specification):
                             'primaryKey type ({0}) is not supported'.format(
                                 type(single_value)))
                 value = modified_value
-            elif type(value) == str:
+            elif type(value) == compat.str:
                 if value not in field_names:
                     raise AttributeError(
                         "Unknown '{0}' cannot be primaryKey".format(

--- a/datapackage/sources.py
+++ b/datapackage/sources.py
@@ -1,10 +1,11 @@
-import sys
-if sys.version_info[0] < 3:
-    next = lambda x: x.next()
-    bytes = str
-    str = unicode
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from .util import Specification, is_url, is_email
+from . import compat
 
 
 class Source(Specification):
@@ -16,9 +17,9 @@ class Source(Specification):
     Each source hash may have name, web and email fields.
     """
 
-    SPECIFICATION = {'name': str,
-                     'web': str,
-                     'email': str}
+    SPECIFICATION = {'name': compat.str,
+                     'web': compat.str,
+                     'email': compat.str}
 
     @property
     def web(self):

--- a/datapackage/util.py
+++ b/datapackage/util.py
@@ -1,17 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import sys
 import os
 import json
-import urllib
 import re
 from collections import namedtuple
-
-if sys.version_info[0] < 3:
-    import urlparse
-    urllib.parse = urlparse
-    urllib.request = urllib
-    next = lambda x: x.next()
-    bytes = str
-    str = unicode
+from . import compat
 
 
 class Specification(dict):
@@ -39,16 +37,16 @@ class Specification(dict):
                     if field_choice in kwargs:
                         found = True
                 if not found:
-                    missing_fields.append(str(' or ').join(field))
+                    missing_fields.append(' or '.join(field))
             else:
                 if field not in kwargs:
                     missing_fields.append(field)
         if missing_fields:
             raise ValueError('Required fields for {0} missing: {1}'.format(
                 self.__class__.__name__,
-                str(' AND ').join(missing_fields)))
+                ' AND '.join(missing_fields)))
 
-        for (key, value) in kwargs.iteritems():
+        for (key, value) in kwargs.items():
             self.__setattr__(key, value)
 
     def __getattr__(self, attribute):
@@ -92,7 +90,7 @@ class Specification(dict):
                     raise TypeError(
                         "Attribute '{0}' ({1}) should be {2}".format(
                             attribute, type(value),
-                            ' or '.join([str(s) for s in spec_type])))
+                            ' or '.join([s for s in spec_type])))
         elif not self.EXTENDABLE:
             raise AttributeError(
                 "Attribute '{0}' is not allowed in a '{1}' object".format(
@@ -221,11 +219,11 @@ def format_version(version):
 
     """
     major, minor, patch, prerelease, metadata = version
-    version = u".".join([str(major), str(minor), str(patch)])
+    version = "{0}.{1}.{2}".format(major, minor, patch)
     if prerelease:
-        version = u"{0}-{1}".format(version, prerelease)
+        version = "{0}-{1}".format(version, prerelease)
     if metadata:
-        version = u"{0}+{1}".format(version, metadata)
+        version = "{0}+{1}".format(version, metadata)
     return version
 
 
@@ -257,7 +255,7 @@ def is_local(path):
     file: scheme)
 
     """
-    parsed_results = urllib.parse.urlparse(path)
+    parsed_results = compat.parse.urlparse(path)
     return parsed_results.scheme == '' or parsed_results.netloc == ''
 
 
@@ -266,7 +264,7 @@ def is_url(path):
     check just looks if the scheme is HTTP or HTTPS.
 
     """
-    parsed_results = urllib.parse.urlparse(path)
+    parsed_results = compat.parse.urlparse(path)
     return parsed_results.scheme == 'http' or parsed_results.scheme == 'https'
 
 
@@ -288,7 +286,7 @@ def is_mimetype(val):
 
 
 def get_size_from_url(url):
-    site = urllib.urlopen(url)
+    site = compat.urlopen(url)
     meta = site.info()
     size = int(meta.getheaders("Content-Length")[0])
     return size

--- a/datapackage/util.py
+++ b/datapackage/util.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 
 import sys
 import os
+import io
 import json
 import re
 from collections import namedtuple
@@ -90,7 +91,7 @@ class Specification(dict):
                     raise TypeError(
                         "Attribute '{0}' ({1}) should be {2}".format(
                             attribute, type(value),
-                            ' or '.join([s for s in spec_type])))
+                            ' or '.join([compat.str(s) for s in spec_type])))
         elif not self.EXTENDABLE:
             raise AttributeError(
                 "Attribute '{0}' is not allowed in a '{1}' object".format(
@@ -243,7 +244,7 @@ def load_licenses():
     # can read in the licenses file
     dirname = os.path.split(os.path.realpath(__file__))[0]
     filename = os.path.join(dirname, "data", "licenses.json")
-    with open(filename, "r") as fh:
+    with io.open(filename, "r") as fh:
         licenses = json.load(fh)
     return licenses
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
 flake8==2.2.2
 mock==1.0.1
-nose==1.3.3
+nose==1.3.4
 Sphinx==1.2.3

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import io
 
 try:
     from setuptools import setup
@@ -7,7 +13,7 @@ except ImportError:
     from distutils.core import setup
 
 description = "Manage and load dataprotocols.org Data Packages"
-with open('README.rst') as readme:
+with io.open('README.rst') as readme:
     long_description = readme.read()
 
 setup(

--- a/tests/test_datapackage.py
+++ b/tests/test_datapackage.py
@@ -4,10 +4,11 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import io
 import datapackage
 from nose.tools import raises
 import unittest
-from mock import Mock, patch
+from datapackage.compat import mock as mocklib
 
 
 class TestDatapackage(object):
@@ -197,14 +198,14 @@ class TestDatapackage(object):
         self.dpkg.image = "bar.jpg"
         assert self.dpkg.image == "bar.jpg"
 
-    @patch('urllib.urlopen')
+    @mocklib.patch('datapackage.compat.urlopen')
     def test_web_url(self, mock_urlopen):
         """Try reading a datapackage from the web"""
 
         # setup the mock for url read
-        with open("tests/cpi/datapackage.json", "r") as fh:
+        with io.open("tests/cpi/datapackage.json", "r") as fh:
             metadata = fh.read()
-        mock = Mock()
+        mock = mocklib.Mock()
         mock.read.side_effect = [metadata]
         mock_urlopen.return_value = mock
 

--- a/tests/test_datapackage.py
+++ b/tests/test_datapackage.py
@@ -1,3 +1,9 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import datapackage
 from nose.tools import raises
 import unittest
@@ -71,7 +77,7 @@ class TestDatapackage(object):
     def test_get_datapackage_version(self):
         """Test getting the datapackage version"""
         assert self.dpkg.datapackage_version == "1.0-beta.10"
- 
+
     @raises(ValueError)
     def test_get_empty_datapackage_version(self):
         """Check that an error is thrown then the datapackage version is an

--- a/tests/test_licenses.py
+++ b/tests/test_licenses.py
@@ -1,3 +1,9 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from nose.tools import raises
 from datapackage.licenses import License
 

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -1,20 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import datapackage
+from datapackage import compat
 import posixpath
 from nose.tools import raises
 from mock import Mock, patch
-import sys
-
-if sys.version_info[0] < 3:
-    next = lambda x: x.next()
-    bytes = str
-    str = unicode
 
 
 class TestDatapackage(object):
     def setup(self):
         self.dpkg = datapackage.DataPackage("tests/test.dpkg")
         kwargs = self.dpkg['resources'][0]
-        kwargs['datapackage_uri'] = str(self.dpkg.base)
+        kwargs['datapackage_uri'] = compat.str(self.dpkg.base)
         self.resource = datapackage.Resource(**kwargs)
 
     def teardown(self):
@@ -90,7 +91,7 @@ class TestDatapackage(object):
 
     def test_set_path(self):
         """Check that setting the path works"""
-        self.resource.path = str("barfoo.json")
+        self.resource.path = compat.str("barfoo.json")
         assert self.resource.path == "barfoo.json"
         assert self.resource.fullpath == posixpath.join(self.dpkg.base,
                                                         "barfoo.json")
@@ -113,14 +114,14 @@ class TestDatapackage(object):
 
     def test_set_url(self):
         """Try setting the resource url"""
-        self.resource.url = str("https://www.google.com")
+        self.resource.url = compat.str("https://www.google.com")
         assert self.resource.url == "https://www.google.com",\
             self.resource.url
 
     @raises(ValueError)
     def test_set_bad_url(self):
         """Try setting the resource url to an invalid url"""
-        self.resource.url = str("google")
+        self.resource.url = compat.str("google")
 
     def test_get_name(self):
         """Try reading the resource name"""
@@ -129,11 +130,11 @@ class TestDatapackage(object):
     def test_get_default_name(self):
         """Try reading the default resource name"""
         del self.resource['name']
-        assert self.resource.name == str('')
+        assert self.resource.name == compat.str('')
 
     def test_set_name(self):
         """Try setting the resource name"""
-        self.resource.name = str("barfoo")
+        self.resource.name = compat.str("barfoo")
         assert self.resource.name == "barfoo"
 
     def test_set_name_to_none(self):

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -8,7 +8,7 @@ import datapackage
 from datapackage import compat
 import posixpath
 from nose.tools import raises
-from mock import Mock, patch
+from datapackage.compat import mock as mocklib
 
 
 class TestDatapackage(object):
@@ -22,10 +22,10 @@ class TestDatapackage(object):
         pass
 
     def patch_urlopen_size(self, mock_urlopen, size):
-        mock_meta = Mock()
+        mock_meta = mocklib.Mock()
         mock_meta.getheaders.side_effect = [[size]]
 
-        mock_site = Mock()
+        mock_site = mocklib.Mock()
         mock_site.info.return_value = mock_meta
 
         mock_urlopen.return_value = mock_site
@@ -145,11 +145,11 @@ class TestDatapackage(object):
     @raises(ValueError)
     def test_set_invalid_name(self):
         """Try setting the resource name to an invalid name"""
-        self.resource.name = str("foo bar")
+        self.resource.name = "foo bar"
 
     def test_get_format(self):
         """Try reading the resource format"""
-        assert self.resource.format == str("json")
+        assert self.resource.format == "json"
 
     def test_get_default_format(self):
         """Try reading the default resource format"""
@@ -158,7 +158,7 @@ class TestDatapackage(object):
 
     def test_set_format(self):
         """Try setting the resource format"""
-        self.resource.format = str('csv')
+        self.resource.format = 'csv'
         assert self.resource.format == 'csv'
 
     def test_set_format_to_none(self):
@@ -178,7 +178,7 @@ class TestDatapackage(object):
 
     def test_set_mediatype(self):
         """Try setting the resource mediatype"""
-        self.resource.mediatype = str('text/csv')
+        self.resource.mediatype = 'text/csv'
         assert self.resource.mediatype == 'text/csv'
 
     def test_set_mediatype_to_none(self):
@@ -190,7 +190,7 @@ class TestDatapackage(object):
     @raises(ValueError)
     def test_set_invalid_mediatype(self):
         """Try setting the resource mediatype to an invalid mimetype"""
-        self.resource.mediatype = str("foo")
+        self.resource.mediatype = "foo"
 
     def test_get_encoding(self):
         """Try reading the resource encoding"""
@@ -203,7 +203,7 @@ class TestDatapackage(object):
 
     def test_set_encoding(self):
         """Try setting the resource encoding"""
-        self.resource.encoding = str('latin1')
+        self.resource.encoding = 'latin1'
         assert self.resource.encoding == 'latin1'
 
     def test_set_encoding_to_none(self):
@@ -214,40 +214,40 @@ class TestDatapackage(object):
 
     def test_guess_mediatype(self):
         assert self.resource._guess_mediatype() == 'application/json'
-        self.resource.path = str("foo.csv")
+        self.resource.path = "foo.csv"
         assert self.resource._guess_mediatype() == 'text/csv'
-        self.resource.path = str("foo.jpg")
+        self.resource.path = "foo.jpg"
         assert self.resource._guess_mediatype() == 'image/jpeg'
 
         self.resource.path = None
         assert self.resource._guess_mediatype() == 'application/json'
-        self.resource.url = str("http://foobar.com/foo.csv")
+        self.resource.url = "http://foobar.com/foo.csv"
         assert self.resource._guess_mediatype() == 'text/csv'
-        self.resource.url = str("http://foobar.com/foo.jpg")
+        self.resource.url = "http://foobar.com/foo.jpg"
         assert self.resource._guess_mediatype() == 'image/jpeg'
 
     def test_guess_format(self):
         assert self.resource._guess_format() == 'json'
-        self.resource.path = str("foo.csv")
+        self.resource.path = "foo.csv"
         assert self.resource._guess_format() == 'csv'
-        self.resource.path = str("foo.jpg")
+        self.resource.path = "foo.jpg"
         assert self.resource._guess_format() == 'jpg'
 
         self.resource.path = None
-        self.resource.url = str("http://foobar.com/foo.json")
+        self.resource.url = "http://foobar.com/foo.json"
         assert self.resource._guess_format() == 'json'
-        self.resource.url = str("http://foobar.com/foo.csv")
+        self.resource.url = "http://foobar.com/foo.csv"
         assert self.resource._guess_format() == 'csv'
-        self.resource.url = str("http://foobar.com/foo.jpg")
+        self.resource.url = "http://foobar.com/foo.jpg"
         assert self.resource._guess_format() == 'jpg'
 
         self.resource.url = None
-        self.resource.mediatype = str("application/json")
+        self.resource.mediatype = "application/json"
         assert self.resource._guess_format() == 'json'
-        self.resource.mediatype = str("text/csv")
+        self.resource.mediatype = "text/csv"
         assert self.resource._guess_format() == 'csv'
-        self.resource.mediatype = str("image/jpeg")
-        assert self.resource._guess_format() == 'jpe'
+        self.resource.mediatype = "image/jpeg"
+        assert self.resource._guess_format() == 'jpeg'
 
     def test_data_bytes(self):
         """Checks that the size is computed correctly from the data"""
@@ -275,7 +275,7 @@ class TestDatapackage(object):
         self.resource.path = None
         self.resource._path_bytes()
 
-    @patch('urllib.urlopen')
+    @mocklib.patch('datapackage.compat.urlopen')
     def test_url_bytes(self, mock_urlopen):
         """Checks that the size is computed correctly from the url"""
         self.patch_urlopen_size(mock_urlopen, '14')
@@ -320,7 +320,7 @@ class TestDatapackage(object):
         self.resource.update_bytes()
         assert self.resource.bytes == 14
 
-    @patch('urllib.urlopen')
+    @mocklib.patch('datapackage.compat.urlopen')
     def test_compute_bytes_from_url(self, mock_urlopen):
         """Test computing the size from the url"""
         self.patch_urlopen_size(mock_urlopen, '14')
@@ -330,7 +330,7 @@ class TestDatapackage(object):
         self.resource.update_bytes()
         assert self.resource.bytes == 14
 
-    @patch('urllib.urlopen')
+    @mocklib.patch('datapackage.compat.urlopen')
     def test_update_bytes_url_unchanged(self, mock_urlopen):
         """Test that updating the size from the url does not throw an
         error when the size has not changed.
@@ -362,7 +362,7 @@ class TestDatapackage(object):
         self.resource.update_bytes()
 
     @raises(RuntimeError)
-    @patch('urllib.urlopen')
+    @mocklib.patch('datapackage.compat.urlopen')
     def test_update_bytes_url_changed(self, mock_urlopen):
         """Check that updating the bytes from the url throws an error when the
         size has changed.
@@ -395,7 +395,7 @@ class TestDatapackage(object):
         assert self.resource.bytes == 14
         assert self.resource['bytes'] == 14
 
-    @patch('urllib.urlopen')
+    @mocklib.patch('datapackage.compat.urlopen')
     def test_update_bytes_url_changed_unverified(self, mock_urlopen):
         """Check that updating the bytes from the url works, when the size has
         changed but the size is not being verified.
@@ -455,7 +455,7 @@ class TestDatapackage(object):
         self.resource.sources = None
         assert 'sources' not in self.resource
         self.resource.sources = [
-            {"name": str("foo"), "web": str("https://bar.com/")}]
+            {"name": "foo", "web": "https://bar.com/"}]
         sources = self.resource.sources
         assert len(sources) == 1
         assert sources[0]["name"] == "foo"
@@ -463,7 +463,7 @@ class TestDatapackage(object):
 
     def test_add_source(self):
         """Try adding a new source with add_source"""
-        self.resource.add_source(str("foo"), email=str("bar@test.com"))
+        self.resource.add_source("foo", email="bar@test.com")
         sources = self.resource.sources
         assert len(sources) == 2
         assert sources[0]["name"] == "World Bank and OECD"
@@ -476,21 +476,21 @@ class TestDatapackage(object):
         required = datapackage.schema.Constraints(required=True)
 
         title = datapackage.schema.Field(
-            name=str('title'), title=str('Title of Batman movie'),
-            type=str('string'), constraints=required)
+            name='title', title='Title of Batman movie',
+            type='string', constraints=required)
         actor = datapackage.schema.Field(
-            name=str('actor'), title=str('Actor portraying Batman'))
+            name='actor', title='Actor portraying Batman')
         villain = datapackage.schema.Field(
-            name=str('villain'), title=str('Movie villain'))
+            name='villain', title='Movie villain')
 
         schema = datapackage.schema.Schema(
             fields=[title, actor, villain],
             primaryKey=[title, villain])
 
         reference = datapackage.schema.Reference(
-            datapackage=str('http://gotham.us/datapackages'),
-            resource=str('villains'),
-            fields=[str('name')])
+            datapackage='http://gotham.us/datapackages',
+            resource='villains',
+            fields=['name'])
         foreign_key = datapackage.schema.ForeignKey(fields=[villain],
                                                     reference=reference)
 
@@ -499,7 +499,7 @@ class TestDatapackage(object):
         # In the assertions we will access the schema as a dictionary because
         # that's how it should get serialized
         assert 'fields' in schema, 'Fields not found in schema'
-        expected_field_order = [str('title'), str('actor'), str('villain')]
+        expected_field_order = ['title', 'actor', 'villain']
         assert [f.name for f in schema['fields']] == expected_field_order, \
             'Field order is incorrect'
         # Constraints for first field should be required == True
@@ -511,19 +511,19 @@ class TestDatapackage(object):
             'Field title changes'
 
         assert 'primaryKey' in schema, 'primaryKey not found in schema'
-        assert schema.primaryKey == [u'title', u'villain'], \
+        assert schema.primaryKey == ['title', 'villain'], \
             'primaryKey is incorrect in schema'
 
         assert 'foreignKeys' in schema, 'foreignKeys not found in schema'
         assert len(schema['foreignKeys']) == 1, \
             'foreignKeys does not hold a single foreignKey'
-        assert schema['foreignKeys'][0]['fields'] == [str('villain')]
+        assert schema['foreignKeys'][0]['fields'] == ['villain']
         schema_reference = schema['foreignKeys'][0]['reference']
         assert schema_reference['datapackage'] == reference.datapackage, \
             'Datapackage in reference changess'
         assert schema_reference['resource'] == reference.resource, \
             'Resource in reference changes'
-        assert schema_reference['fields'] == [str('name')], \
+        assert schema_reference['fields'] == ['name'], \
             'Fields in reference changes'
 
     @raises(AttributeError)
@@ -532,21 +532,21 @@ class TestDatapackage(object):
 
     @raises(ValueError)
     def test_resource_schema_field_missing_name(self):
-        datapackage.schema.Field(title=str('Movie villain'))
+        datapackage.schema.Field(title='Movie villain')
 
     @raises(AttributeError)
     def test_resource_schema_field_invalid_attribute(self):
         datapackage.schema.Field(
-            name=str('villain'), joker=str('Movie villain'))
+            name='villain', joker='Movie villain')
 
     @raises(AttributeError)
     def test_resource_schema_invalid_attribute(self):
         title = datapackage.schema.Field(
-            name=str('title'), title=str('Title of Batman movie'))
+            name='title', title='Title of Batman movie')
         actor = datapackage.schema.Field(
-            name=str('actor'), title=str('Actor portraying Batman'))
+            name='actor', title='Actor portraying Batman')
         villain = datapackage.schema.Field(
-            name=str('villain'), title=str('Movie villain'))
+            name='villain', title='Movie villain')
         datapackage.schema.Schema(
             fields=[title, actor, villain],
             description='This dataset resource shows all the Batman movies')
@@ -554,13 +554,13 @@ class TestDatapackage(object):
     @raises(AttributeError)
     def test_resource_schema_bad_primaryKey(self):
         title = datapackage.schema.Field(
-            name=str('title'), title=str('Title of Batman movie'))
+            name='title', title='Title of Batman movie')
         actor = datapackage.schema.Field(
-            name=str('actor'), title=str('Actor portraying Batman'))
+            name='actor', title='Actor portraying Batman')
         villain = datapackage.schema.Field(
-            name=str('villain'), title=str('Movie villain'))
+            name='villain', title='Movie villain')
         penguin = datapackage.schema.Field(
-            name=str('penguin'), title=str('Oswald Chesterfield Cobblepot'))
+            name='penguin', title='Oswald Chesterfield Cobblepot')
         schema = datapackage.schema.Schema(
             fields=[title, actor, villain],
             primaryKey=[title, penguin])
@@ -574,7 +574,7 @@ class TestDatapackage(object):
     def test_foreign_key_missing_required_reference(self):
         """Check if error is raised when required foreign key values are
         missing"""
-        datapackage.schema.ForeignKey(fields=str("where-is-my-reference"))
+        datapackage.schema.ForeignKey(fields="where-is-my-reference")
 
     @raises(ValueError)
     def test_reference_missing_required_fields(self):
@@ -585,16 +585,16 @@ class TestDatapackage(object):
     @raises(AttributeError)
     def test_resource_schema_foreign_key_bad_attribute(self):
         villain = datapackage.schema.Field(
-            name=str('villain'), title=str('Movie villain'))
-        villain_name = datapackage.schema.Field(name=str('name'))
+            name='villain', title='Movie villain')
+        villain_name = datapackage.schema.Field(name='name')
         villains = datapackage.schema.Reference(fields=[villain_name])
         datapackage.schema.ForeignKey(
             fields=[villain], reference=villains, villain='Dr. Hugo Strange')
 
     def test_resource_schema_foreign_key_Field_field(self):
         villain = datapackage.schema.Field(
-            name=str('villain'), title=str('Movie villain'))
-        villain_name = datapackage.schema.Field(name=str('name'))
+            name='villain', title='Movie villain')
+        villain_name = datapackage.schema.Field(name='name')
         villains = datapackage.schema.Reference(fields=villain_name)
         foreign_key = datapackage.schema.ForeignKey(
             fields=villain, reference=villains)
@@ -602,27 +602,27 @@ class TestDatapackage(object):
             'Foreign key could not receive a Field object'
 
     def test_resource_schema_foreign_key_str_field(self):
-        villains = datapackage.schema.Reference(fields=str("name"))
+        villains = datapackage.schema.Reference(fields="name")
         foreign_key = datapackage.schema.ForeignKey(
-            fields=str('villain'), reference=villains)
-        assert foreign_key['fields'] == str('villain'), \
+            fields='villain', reference=villains)
+        assert foreign_key['fields'] == 'villain', \
             'Foreign key could not receive a string field representation'
 
 
     @raises(AttributeError)
     def test_resource_schema_reference_bad_attribute(self):
         reference = datapackage.schema.Reference(
-            datapackage=str('http://gotham.us/datapackages'),
-            badpeople=str('villains'),
-            fields=[str('name')])
+            datapackage='http://gotham.us/datapackages',
+            badpeople='villains',
+            fields=['name'])
 
     @raises(ValueError)
     def test_ressource_schema_foreign_key_field_inconsistency(self):
         reference = datapackage.schema.Reference(
-            datapackage=str('http://gotham.us/datapackages'),
-            resource=str('villains'),
-            fields=[str('name'), str('catwoman')])
+            datapackage='http://gotham.us/datapackages',
+            resource='villains',
+            fields=['name', 'catwoman'])
         villain = datapackage.schema.Field(
-            name=str('villain'), title=str('Movie villain'))
+            name='villain', title='Movie villain')
         foreign_key = datapackage.schema.ForeignKey(fields=[villain],
                                                     reference=reference)

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -247,7 +247,7 @@ class TestDatapackage(object):
         self.resource.mediatype = "text/csv"
         assert self.resource._guess_format() == 'csv'
         self.resource.mediatype = "image/jpeg"
-        assert self.resource._guess_format() == 'jpeg'
+        assert self.resource._guess_format() == 'jpg'
 
     def test_data_bytes(self):
         """Checks that the size is computed correctly from the data"""

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,11 +1,13 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from nose.tools import raises
 from datapackage.sources import Source
+from datapackage import compat
 
-import sys
-if sys.version_info[0] < 3:
-    next = lambda x: x.next()
-    bytes = str
-    str = unicode
 
 class TestSources(object):
 

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -12,9 +12,9 @@ from datapackage import compat
 class TestSources(object):
 
     def setup(self):
-        self.name = str("World Bank and OECD")
-        self.web = str("http://data.worldbank.org/indicator/NY.GDP.MKTP.CD")
-        self.email = str("info@worldbank.org")
+        self.name = "World Bank and OECD"
+        self.web = "http://data.worldbank.org/indicator/NY.GDP.MKTP.CD"
+        self.email = "info@worldbank.org"
 
     def teardown(self):
         pass

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,3 +1,9 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import datapackage.util as util
 from nose.tools import raises
 


### PR DESCRIPTION
**DO NOT MERGE: WORK IN PROGRESS**

This pull request is for discussion as I port over parts I need while using datapackage.

The first thing that needs agreement, is that I am not intending to use `six`. `six` is great, especially for porting over large projects (e.g.: Django), but here, we have a small, focussed codebase, that is quite manageable without it. I've been working recently on similar small codebases for Py2.7/3.3+ support, and  find the following working well:

* Using a compat.py file (several high profile Python libraries use this, e.g., [Requests](https://github.com/kennethreitz/requests))
* Following the official [porting guide](https://docs.python.org/3/howto/pyporting.html)

For examples, see [Good Tables](https://github.com/okfn/goodtables) and [JTSKit](https://github.com/okfn/jtskit-py), which I'm currently working on with this approach.

So, I'm raising this now to ensure that this approach is legit here, before I get too far into the port.