### PR TITLE
unicode_literals breaks package_data on Python 2.7.x.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-from __future__ import unicode_literals
 
 import io
 


### PR DESCRIPTION
Fixes #39